### PR TITLE
Fix client initialization when loaded from local files

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
-import { COMPONENTS, getComponent } from "./thermo-data.js";
-import { flashCalculation } from "./eos.js";
+(function (global) {
+const { COMPONENTS, getComponent } = global.ThermoData;
+const { flashCalculation } = global.EOS;
 
 let componentRows;
 let addComponentBtn;
@@ -323,3 +324,4 @@ if (document.readyState === "loading") {
 } else {
   initializeUi();
 }
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/eos.js
+++ b/eos.js
@@ -1,13 +1,10 @@
-import {
-  GAS_CONSTANT,
-  getComponent,
-  binaryInteraction,
-} from "./thermo-data.js";
-import {
+(function (global) {
+const { GAS_CONSTANT, getComponent, binaryInteraction } = global.ThermoData;
+const {
   idealGasHeatCapacityMixture,
   mixtureIdealEnthalpy,
-} from "./heat-capacity.js";
-import { transportProperties } from "./transport.js";
+} = global.HeatCapacity;
+const { transportProperties } = global.Transport;
 
 const SQRT2 = Math.SQRT2;
 const R_SI = GAS_CONSTANT * 100; // J·L⁻¹ -> convert bar·L to J·mol⁻¹·K⁻¹ when multiplied by T
@@ -293,7 +290,7 @@ function splitMixture(componentIds, z, K) {
   return { type: "two-phase", vaporFraction: V, x: xNorm, y: yNorm };
 }
 
-export function flashCalculation({ componentIds, composition, temperature, pressure }) {
+function flashCalculation({ componentIds, composition, temperature, pressure }) {
   const T = temperature;
   const P = pressure;
   const components = componentIds.map((id) => getComponent(id));
@@ -351,3 +348,14 @@ export function flashCalculation({ componentIds, composition, temperature, press
     },
   };
 }
+
+const api = {
+  flashCalculation,
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = api;
+}
+
+global.EOS = api;
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/heat-capacity.js
+++ b/heat-capacity.js
@@ -1,4 +1,5 @@
-import { getComponent } from "./thermo-data.js";
+(function (global) {
+const { getComponent } = global.ThermoData;
 
 const REFERENCE_T = 298.15; // K
 
@@ -41,14 +42,14 @@ function shomateIntegral(component, T1, T2) {
   return integral(T2) - integral(T1);
 }
 
-export function idealGasHeatCapacity(componentId, temperature) {
+function idealGasHeatCapacity(componentId, temperature) {
   const component = getComponent(componentId);
   if (!component) throw new Error(`Unknown component: ${componentId}`);
   const T = ensureRange(component, temperature);
   return shomateCp(component, T);
 }
 
-export function idealGasHeatCapacityMixture(components, composition, temperature) {
+function idealGasHeatCapacityMixture(components, composition, temperature) {
   let cp = 0;
   for (let i = 0; i < components.length; i += 1) {
     const comp = components[i];
@@ -58,7 +59,7 @@ export function idealGasHeatCapacityMixture(components, composition, temperature
   return cp;
 }
 
-export function idealGasEnthalpy(componentId, temperature) {
+function idealGasEnthalpy(componentId, temperature) {
   const component = getComponent(componentId);
   if (!component) throw new Error(`Unknown component: ${componentId}`);
   const T = ensureRange(component, temperature);
@@ -66,7 +67,7 @@ export function idealGasEnthalpy(componentId, temperature) {
   return shomateIntegral(component, reference, T);
 }
 
-export function mixtureIdealEnthalpy(components, composition, temperature) {
+function mixtureIdealEnthalpy(components, composition, temperature) {
   let h = 0;
   for (let i = 0; i < components.length; i += 1) {
     const comp = components[i];
@@ -75,3 +76,17 @@ export function mixtureIdealEnthalpy(components, composition, temperature) {
   }
   return h;
 }
+
+const api = {
+  idealGasHeatCapacity,
+  idealGasHeatCapacityMixture,
+  idealGasEnthalpy,
+  mixtureIdealEnthalpy,
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = api;
+}
+
+global.HeatCapacity = api;
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/index.html
+++ b/index.html
@@ -70,6 +70,10 @@
       </p>
     </footer>
 
-    <script type="module" src="app.js"></script>
+    <script src="thermo-data.js" defer></script>
+    <script src="heat-capacity.js" defer></script>
+    <script src="transport.js" defer></script>
+    <script src="eos.js" defer></script>
+    <script src="app.js" defer></script>
   </body>
 </html>

--- a/thermo-data.js
+++ b/thermo-data.js
@@ -1,6 +1,7 @@
-export const GAS_CONSTANT = 0.08314462618; // L·bar·mol⁻¹·K⁻¹
+(function (global) {
+const GAS_CONSTANT = 0.08314462618; // L·bar·mol⁻¹·K⁻¹
 
-export const COMPONENTS = [
+const COMPONENTS = [
   {
     id: "C1",
     name: "Метан",
@@ -258,7 +259,7 @@ export const COMPONENTS = [
   },
 ];
 
-export const BINARY_INTERACTIONS = {
+const BINARY_INTERACTIONS = {
   C1: { H2O: 0.35, Air: 0.03, N2: 0.025, O2: 0.03 },
   C2: { H2O: 0.35, Air: 0.03, N2: 0.025, O2: 0.03 },
   C3: { H2O: 0.35, Air: 0.03, N2: 0.025, O2: 0.03 },
@@ -291,13 +292,28 @@ export const BINARY_INTERACTIONS = {
   O2: { C1: 0.03, C2: 0.03, C3: 0.03, iC4: 0.035, nC4: 0.035, C5: 0.035, C6: 0.04, C7: 0.04, C8: 0.042, C9: 0.042, C10: 0.045, H2O: 0.03 },
 };
 
-export function getComponent(id) {
+function getComponent(id) {
   return COMPONENTS.find((item) => item.id === id);
 }
 
-export function binaryInteraction(i, j) {
+function binaryInteraction(i, j) {
   if (i === j) return 0;
   const row = BINARY_INTERACTIONS[i];
   if (!row) return 0;
   return row[j] ?? 0;
 }
+
+const api = {
+  GAS_CONSTANT,
+  COMPONENTS,
+  BINARY_INTERACTIONS,
+  getComponent,
+  binaryInteraction,
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = api;
+}
+
+global.ThermoData = api;
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/transport.js
+++ b/transport.js
@@ -1,4 +1,5 @@
-import { getComponent } from "./thermo-data.js";
+(function (global) {
+const { getComponent } = global.ThermoData;
 
 const UNIVERSAL_R = 8.314462618;
 
@@ -54,7 +55,7 @@ function leeGonzalezEakinViscosity(T, density, mixture) {
   return viscosityCp * 1e-3; // Pa·s
 }
 
-export function transportProperties({
+function transportProperties({
   temperature,
   pressure,
   density,
@@ -84,3 +85,14 @@ export function transportProperties({
     thermalConductivity,
   };
 }
+
+const api = {
+  transportProperties,
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = api;
+}
+
+global.Transport = api;
+})(typeof globalThis !== "undefined" ? globalThis : window);


### PR DESCRIPTION
## Summary
- wrap the thermo, transport and EOS helpers in global namespaces so they work without ES modules
- update the UI logic to consume the globals and defer-load the scripts in the required order
- keep functionality intact when the page is opened directly from the file system

## Testing
- playwright smoke test (add component and run a calculation)


------
https://chatgpt.com/codex/tasks/task_e_68c987036098832c880fad60d50b88b6